### PR TITLE
Fix for mongo deprecation warning

### DIFF
--- a/src/database/mongodb.ts
+++ b/src/database/mongodb.ts
@@ -5,6 +5,7 @@ export const getDB = async (url?: string): Promise<Db> => {
     url || process.env.MONGODB_URI || 'mongodb://localhost:27017/radiks-server';
   const client = new MongoClient(_url, {
     useNewUrlParser: true,
+    useUnifiedTopology:true,
     reconnectTries: Number.MAX_VALUE,
     reconnectInterval: 1000, // every 1 second
   });


### PR DESCRIPTION
Fixes deprecation warning:

 ```
$ radiks-server
(node:37750) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
radiks-server is ready on http://localhost:1260
```


Signed-off-by: Mary Anthony <mary@blockstack.com>