### PR TITLE
problem with advanced queries solved

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-ws": "^4.0.0",
     "lodash": "^4.17.11",
     "mongodb": "^3.2.7",
-    "query-to-mongo": "^0.9.0",
+    "qs": "^6.9.1",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "wolfy87-eventemitter": "^5.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5407,6 +5407,11 @@ qs@^6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+qs@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+
 query-string@^6.3.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.7.0.tgz#7e92bf8525140cf8c5ebf500f26716b0de5b7023"
@@ -5415,10 +5420,6 @@ query-string@^6.3.0:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
-
-query-to-mongo@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/query-to-mongo/-/query-to-mongo-0.9.0.tgz#471c427a8425bf863badc8d9792cd064dfe3ca12"
 
 randombytes@^2.0.1:
   version "2.0.6"


### PR DESCRIPTION
This PR solves this issue: https://github.com/blockstack/radiks/issues/67

I've removed query-to-mongo package, because it doesn't work correctly with complex queries, it also did a lot of unnecessary stuff.

I have implemented custom function queryToMongo instead, which supports pagination and returns JS object with the following properties:
- criteria (search mongo query)
- options (mongo options, like limit, sort, and offset)
- links (function which calculates links for pagination, this function uses the same mechanism that mongo-to-query does)

This solution will not break anything, because a lot of features from mongo-to-query were not used in radiks-server. Also I've found out that there was a problem with complex queries stringification in radiks repo. It's solved here https://github.com/blockstack/radiks/pull/71. So this commit should be applied also to fix the issue.

I have also added some simple tests to ensure that radiks-server can support (at least doesn't raise an error) for complex queries with $or operator.