### PR TITLE
Feature/validate usernames - Unverifiable usernames

### DIFF
--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -96,7 +96,7 @@ class Validator {
    * the Gaia URL to any Gaia URL in that user's profile.json
    */
   async validateUsername(): Promise<boolean> {
-    if (!(this.attrs.username)) {
+    if (!(this.attrs.username) || (this.attrs.usernameUnverified)) {
       return true;
     }
     if (!(this.gaiaURL)) {
@@ -108,7 +108,8 @@ class Validator {
     const foundUrl = gaiaAddresses.find((address) => address === gaiaAddress);
 
     if (!foundUrl) {
-      return errorMessage('Username does not match provided Gaia URL');
+      this.attrs.usernameUnverified = this.attrs.username;
+      return true;
     }
 
     return true;

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -96,8 +96,11 @@ class Validator {
    * the Gaia URL to any Gaia URL in that user's profile.json
    */
   async validateUsername(): Promise<boolean> {
-    if (!(this.attrs.username && this.gaiaURL)) {
+    if (!(this.attrs.username)) {
       return true;
+    }
+    if (!(this.gaiaURL)) {
+      return errorMessage(`No 'gaiaURL' attribute, which is required for models with usernames.`);
     }
     const gaiaAddresses = await this.fetchProfileGaiaAddresses();
     const gaiaAddressParts = this.gaiaURL.split('/');


### PR DESCRIPTION
This PR
* accepts models that contain unverifiable usernames and adds an attribute `usernameUnverified`
* builds on top of #42 